### PR TITLE
Fixed typos in SmartBinder

### DIFF
--- a/src/main/java/com/headius/invokebinder/SmartBinder.java
+++ b/src/main/java/com/headius/invokebinder/SmartBinder.java
@@ -235,7 +235,7 @@ public class SmartBinder {
      */
     public SmartBinder foldStatic(String newName, Class<?> target, String method) {
         Binder newBinder = binder.foldStatic(target, method);
-        return new SmartBinder(this, signature().prependArg(newName, newBinder.type().parameterType(0)), binder);
+        return new SmartBinder(this, signature().prependArg(newName, newBinder.type().parameterType(0)), newBinder);
     }
 
     /**
@@ -251,7 +251,7 @@ public class SmartBinder {
      */
     public SmartBinder foldVirtual(String newName, Lookup lookup, String method) {
         Binder newBinder = binder.foldVirtual(lookup, method);
-        return new SmartBinder(this, signature().prependArg(newName, newBinder.type().parameterType(0)), binder);
+        return new SmartBinder(this, signature().prependArg(newName, newBinder.type().parameterType(0)), newBinder);
     }
 
     /**
@@ -267,7 +267,7 @@ public class SmartBinder {
      */
     public SmartBinder foldVirtual(String newName, String method) {
         Binder newBinder = binder.foldVirtual(method);
-        return new SmartBinder(this, signature().prependArg(newName, newBinder.type().parameterType(0)), binder);
+        return new SmartBinder(this, signature().prependArg(newName, newBinder.type().parameterType(0)), newBinder);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/test/java/com/headius/invokebinder/SmartBinderTest.java
+++ b/src/test/java/com/headius/invokebinder/SmartBinderTest.java
@@ -257,7 +257,7 @@ public class SmartBinderTest {
         assertEquals("foogoodbyebargoodbye", (String)handle.invokeExact("foo", "bar"));
     }
 
-    @Test
+    @Test   
     public void testIdentity() throws Throwable {
         MethodHandle handle = SmartBinder
                 .from(String.class, "i", int.class)
@@ -269,7 +269,61 @@ public class SmartBinderTest {
         assertEquals(MethodType.methodType(String.class, int.class), handle.type());
         assertEquals("15", (String)handle.invokeExact(15));
     }
-    
+
+
+    @Test
+    public void testFoldStatic() throws Throwable {
+        MethodHandle handle = SmartBinder
+                .from(Subjects.StringIntegerIntegerInteger)
+                .foldStatic("x", Subjects.class, "foldStringIntegerIntegerInteger")
+                .drop("a")
+                .drop("b1")
+                .drop("b2")
+                .drop("b3").printSignature()
+                .invokeStatic(MethodHandles.lookup(), Subjects.class, "upperCase")
+                .handle();
+
+        assertEquals("FORTY_TWO", (String)handle.invokeExact("foo",
+                Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)));
+    }
+
+    @Test
+    public void testFoldVirtual() throws Throwable {
+        MethodHandle handle = SmartBinder
+                .from(Subjects.StringIntegerIntegerInteger)
+                .prepend("this", new Subjects()).printSignature()
+                .foldVirtual("x", "foldVirtualStringIntegerIntegerInteger")
+                .drop("this")
+                .drop("a")
+                .drop("b1")
+                .drop("b2")
+                .drop("b3").printSignature()
+                .invokeStatic(MethodHandles.lookup(), Subjects.class, "upperCase")
+                .handle();
+
+        assertEquals("FORTY_TWO", (String)handle.invokeExact("foo",
+                Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)));
+    }
+
+    @Test
+    public void testFoldVirtualWithLookup() throws Throwable {
+        MethodHandle handle = SmartBinder
+                .from(Subjects.StringIntegerIntegerInteger)
+                .prepend("this", new Subjects()).printSignature()
+                .foldVirtual("x", MethodHandles.lookup(), "foldVirtualStringIntegerIntegerInteger")
+                .drop("this")
+                .drop("a")
+                .drop("b1")
+                .drop("b2")
+                .drop("b3").printSignature()
+                .invokeStatic(MethodHandles.lookup(), Subjects.class, "upperCase")
+                .handle();
+
+        assertEquals("FORTY_TWO", (String)handle.invokeExact("foo",
+                Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)));
+    }
+
+
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
     
     private static final MethodHandle stringInt = Binder

--- a/src/test/java/com/headius/invokebinder/Subjects.java
+++ b/src/test/java/com/headius/invokebinder/Subjects.java
@@ -67,4 +67,18 @@ public class Subjects {
     public String stringIntegersString2(String a, Integer[] bs, String c) {
         return Arrays.deepToString(new Object[]{a, bs, c});
     }
+    
+    public static String foldStringIntegerIntegerInteger(String a, Integer b1, Integer b2, Integer b3) {
+        return "forty_two";
+    }
+
+    public String foldVirtualStringIntegerIntegerInteger(String a, Integer b1, Integer b2, Integer b3) {
+        return "forty_two";
+    }
+
+
+    public static String upperCase(String x) {
+        return x.toUpperCase();
+    }
+    
 }


### PR DESCRIPTION
Convenience foldXXX() methods need to return the newBinder, not the original binder.

