### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,8 @@ language: java
 matrix:
   include:
     - os: linux
+      arch: amd64
+      jdk: openjdk11
+    - os: linux
+      arch: ppc64le
       jdk: openjdk11


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/invokebinder/builds/191618512 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!