### PR TITLE
Use a static logger

### DIFF
--- a/src/main/java/com/headius/invokebinder/Binder.java
+++ b/src/main/java/com/headius/invokebinder/Binder.java
@@ -68,7 +68,7 @@ import java.util.logging.Logger;
  */
 public class Binder {
 
-    private final Logger logger = Logger.getLogger("Invoke Binder");
+    private static final Logger logger = Logger.getLogger("Invoke Binder");
     private final List<Transform> transforms = new LinkedList<>();
     private final List<MethodType> types = new LinkedList<>();
     private final MethodType start;


### PR DESCRIPTION
There's no need to acquire a new logger instance, since they are thread-safe and shared across `getLogger` calls. Those calls do, however, trigger a security check to make sure you have access to the logger, and this led to jruby/jruby#7726.

Ths fix is to use a static logger. A better fix I will consider might be to just remove this feature or require users provide a logger.